### PR TITLE
(feat) Add collaboration between two users for adding items to list

### DIFF
--- a/client/lists/listdetail.html
+++ b/client/lists/listdetail.html
@@ -20,9 +20,9 @@
 
   <div class="items">
     <uib-accordion>
-      <div uib-accordion-group class="panel-default" is-open="status.open">
+      <div uib-accordion-group class="panel-default" is-open="status.open || displayList.draft">
         <uib-accordion-heading>
-          Items <i class="pull-right glyphicon" ng-class="{'glyphicon-chevron-down': status.open, 'glyphicon-chevron-right': !status.open}"></i>
+          Items <i class="pull-right glyphicon" ng-class="{'glyphicon-chevron-down': status.open || displayList.draft, 'glyphicon-chevron-right': !status.open}"></i>
         </uib-accordion-heading>
         <table class="table table-hover">
           <thead>
@@ -40,6 +40,13 @@
             </tr>
           </tbody>
         </table>
+          <form name="addItemForm">
+            <input type="text" ng-model="item.item_name" placeholder="Item Name">
+            <input type="number" ng-model="item.quantity" placeholder="Quantity">
+            <input type="number" ng-model="item.unite_price" placeholder="Cost per Item">
+            <a ng-click="addItemToList(item); item = {}; " class="btn btn-primary btn-sm active">Save Item</a>
+            <a ng-click="submitDraft()" class="btn btn-primary btn-sm active">Submit</a>
+          </form>
       </div>
     </uib-accordion>
   </div>

--- a/client/lists/listdetail.html
+++ b/client/lists/listdetail.html
@@ -36,7 +36,7 @@
             <tr ng-repeat="item in displayList.items">
               <td>{{ item.item_name }}</td>
               <td>{{ item.quantity }}</td>
-              <td>{{ item.unite_price }}</td>
+              <td>{{ item.unite_price }}<span ng-if="item.collab" class="collabLabel"> - added by {{item.collab}}</span></td>
             </tr>
           </tbody>
         </table>

--- a/client/lists/lists.js
+++ b/client/lists/lists.js
@@ -42,7 +42,8 @@ angular.module("crowdcart.lists", ["angularMoment"])
         console.log('alllists', allLists)
         $scope.data.allLists = allLists.filter(function(list){
           //Only showing the list that has not deliverer, and those that do not belong to user, and not overdue
-          return !list.deliverer_id && list.creator_id !== $scope.userid && new Date(list.due_at) >= new Date();
+          // return !list.deliverer_id && list.creator_id !== $scope.userid && new Date(list.due_at) >= new Date();
+          return !list.deliverer_id && list.creator_id !== $scope.userid
         });
       })
       .catch(function(error){
@@ -116,7 +117,6 @@ angular.module("crowdcart.lists", ["angularMoment"])
     if ($scope.displayList.creator_id !== $scope.userid) {
       item.collab = $scope.displayList.collab_email;
     }
-    console.log(item)
     $scope.displayList.items.push(item)
     Lists.updateList($scope.displayList)
       .then(function(res) {

--- a/client/lists/lists.js
+++ b/client/lists/lists.js
@@ -38,6 +38,7 @@ angular.module("crowdcart.lists", ["angularMoment"])
     // Get all lists
     Lists.getAllList()
       .then(function(allLists){
+        console.log('alllists', allLists)
         $scope.data.allLists = allLists.filter(function(list){
           //Only showing the list that has not deliverer, and those that do not belong to user, and not overdue
           return !list.deliverer_id && list.creator_id !== $scope.userid && new Date(list.due_at) >= new Date();
@@ -106,6 +107,19 @@ angular.module("crowdcart.lists", ["angularMoment"])
       .catch(function (error) {
         console.log(error);
       });
+  }
+
+  $scope.addItemToList = function(item) {
+    $scope.displayList.update = true;
+    console.log($scope.displayList)
+    $scope.displayList.items.push(item)
+    Lists.updateList($scope.displayList)
+      .then(function(res) {
+        console.log('added item', res)
+      })
+      .catch(function(err){
+        console.log(err)
+      })
   }
 
 

--- a/client/lists/lists.js
+++ b/client/lists/lists.js
@@ -134,10 +134,24 @@ angular.module("crowdcart.lists", ["angularMoment"])
     Lists.updateList(list)
       .then(function(res) {
         console.log('list updated with collaborator', res)
+        $location.path('/mylists')
       })
       .catch(function (error) {
         console.log(error)
       });
+  }
+
+  $scope.submitDraft = function() {
+    $scope.displayList.draft = 'final';
+    console.log($scope.displayList)
+    Lists.updateList($scope.displayList)
+      .then(function(res){
+        $location.path('/mylists')
+        console.log(res)
+      })
+      .catch(function(err){
+        console.log(err);
+      })
   }
 
   //Google Map initializer

--- a/client/lists/lists.js
+++ b/client/lists/lists.js
@@ -109,6 +109,18 @@ angular.module("crowdcart.lists", ["angularMoment"])
   }
 
 
+  //Add a collaborator to the list
+  $scope.addCollabToList = function(list) {
+    list.showCollabForm = null;
+    Lists.updateList(list)
+      .then(function() {
+        console.log('list updated with collaborator')
+      })
+      .catch(function (error) {
+        console.log(error)
+      });
+  }
+
   //Google Map initializer
   $scope.mapInitialize = function() {
 

--- a/client/lists/lists.js
+++ b/client/lists/lists.js
@@ -113,8 +113,8 @@ angular.module("crowdcart.lists", ["angularMoment"])
   $scope.addCollabToList = function(list) {
     list.showCollabForm = null;
     Lists.updateList(list)
-      .then(function() {
-        console.log('list updated with collaborator')
+      .then(function(res) {
+        console.log('list updated with collaborator', res)
       })
       .catch(function (error) {
         console.log(error)

--- a/client/lists/lists.js
+++ b/client/lists/lists.js
@@ -22,6 +22,7 @@ angular.module("crowdcart.lists", ["angularMoment"])
       // get list data and store on scope
       Lists.getOneList($routeParams.listid)
         .then(function (list) {
+          console.log(list)
           $scope.displayList = list
         })
     }

--- a/client/lists/lists.js
+++ b/client/lists/lists.js
@@ -113,6 +113,10 @@ angular.module("crowdcart.lists", ["angularMoment"])
   $scope.addItemToList = function(item) {
     $scope.displayList.update = true;
     console.log($scope.displayList)
+    if ($scope.displayList.creator_id !== $scope.userid) {
+      item.collab = $scope.displayList.collab_email;
+    }
+    console.log(item)
     $scope.displayList.items.push(item)
     Lists.updateList($scope.displayList)
       .then(function(res) {

--- a/client/lists/lists.js
+++ b/client/lists/lists.js
@@ -22,7 +22,6 @@ angular.module("crowdcart.lists", ["angularMoment"])
       // get list data and store on scope
       Lists.getOneList($routeParams.listid)
         .then(function (list) {
-          console.log(list)
           $scope.displayList = list
         })
     }
@@ -43,6 +42,9 @@ angular.module("crowdcart.lists", ["angularMoment"])
         $scope.data.allLists = allLists.filter(function(list){
           //Only showing the list that has not deliverer, and those that do not belong to user, and not overdue
           // return !list.deliverer_id && list.creator_id !== $scope.userid && new Date(list.due_at) >= new Date();
+          //JY
+          // TODO: Add date verification if user puts nothing for date
+          // Currently old line has been commented out above.
           return !list.deliverer_id && list.creator_id !== $scope.userid
         });
       })
@@ -111,9 +113,11 @@ angular.module("crowdcart.lists", ["angularMoment"])
       });
   }
 
+
+  // Adds an item to the list in draft/collab mode
+  // update = true is used for server to determine whether it's a new list.
   $scope.addItemToList = function(item) {
     $scope.displayList.update = true;
-    console.log($scope.displayList)
     if ($scope.displayList.creator_id !== $scope.userid) {
       item.collab = $scope.displayList.collab_email;
     }
@@ -141,6 +145,9 @@ angular.module("crowdcart.lists", ["angularMoment"])
       });
   }
 
+  //Submit a draft from collab mode
+  // Will set the list to open afterrefresh
+  // TODO: Auto refresh page after submission
   $scope.submitDraft = function() {
     $scope.displayList.draft = 'final';
     console.log($scope.displayList)

--- a/client/lists/mylists.html
+++ b/client/lists/mylists.html
@@ -29,8 +29,9 @@
             </div>
           </td>
           <td><a ng-click="deleteList(this.list._id, $index)" class="btn btn-primary btn-sm active">Delete List</a></td>
-          <td ng-if="!list.deliverer_id">Open</td>
-          <td ng-if="!!list.deliverer_id">In Work!</td>
+          <td ng-if="list.draft"><a ng-click="displayDetail(this.list._id)" class="btn btn-primary btn-sm active">Edit Draft</a></td>
+          <td ng-if="!list.deliverer_id && !list.draft">Open</td>
+          <td ng-if="!!list.deliverer_id && !!list.draft">In Work!</td>
         </tr>
       </tbody>
     </table>

--- a/client/lists/mylists.html
+++ b/client/lists/mylists.html
@@ -23,7 +23,7 @@
             <a ng-click="list.showCollabForm = list._id" ng-if="!list.collab_email" class="btn btn-primary btn-sm active">Add Collaborator</a>
             <div ng-show="list.showCollabForm === list._id" class="collabForm">
               <input ng-model="list.collab_email" placeholder="Enter email address"/>
-              <a ng-click="addCollabToList(list); list.showCollabForm = false" class="btn btn-primary btn-sm active">Add</a>
+              <a ng-click="addCollabToList(list);" class="btn btn-primary btn-sm active">Add</a>
               <a ng-click="list.showCollabForm = false" class="btn btn-warning btn-sm active">Cancel</a>
 
             </div>

--- a/client/lists/mylists.html
+++ b/client/lists/mylists.html
@@ -24,6 +24,8 @@
             <div ng-show="list.showCollabForm === list._id" class="collabForm">
               <input ng-model="list.collab_email" placeholder="Enter email address"/>
               <a ng-click="addCollabToList(list); list.showCollabForm = false" class="btn btn-primary btn-sm active">Add</a>
+              <a ng-click="list.showCollabForm = false" class="btn btn-warning btn-sm active">Cancel</a>
+
             </div>
           </td>
           <td><a ng-click="deleteList(this.list._id, $index)" class="btn btn-primary btn-sm active">Delete List</a></td>

--- a/client/lists/mylists.html
+++ b/client/lists/mylists.html
@@ -14,13 +14,17 @@
         </tr>
       </thead>
       <tbody>
-        <tr class="list" ng-repeat="list in data.lists | orderBy:'due_at' | filter:search">
+        <tr class="list" ng-repeat="list in data.lists track by list._id | orderBy:'due_at' | filter:search">
           <td ng-click="displayDetail(this.list._id)">{{ list.name }}</td>
           <td ng-click="displayDetail(this.list._id)">{{ list.delivery_address.city }}, {{ list.delivery_address.state }}</td>
           <td ng-click="displayDetail(this.list._id)"><span am-time-ago="list.due_at"></span></td>
-          <td>
+          <td ng-init="list.showCollabForm = false" class="center-block">
             <span ng-if="list.collab_email">{{list.collab_email}}</span>
-            <a ng-if="!list.collab_email" class="btn btn-primary btn-sm active">Add Collaborator</a>
+            <a ng-click="list.showCollabForm = list._id" ng-if="!list.collab_email" class="btn btn-primary btn-sm active">Add Collaborator</a>
+            <div ng-show="list.showCollabForm === list._id" class="collabForm">
+              <input ng-model="collabForm" placeholder="Enter email address"/>
+              <a ng-click="addCollabToList(collabForm)" class="btn btn-primary btn-sm active">Add</a>
+            </div>
           </td>
           <td><a ng-click="deleteList(this.list._id, $index)" class="btn btn-primary btn-sm active">Delete List</a></td>
           <td ng-if="!list.deliverer_id">Open</td>

--- a/client/lists/mylists.html
+++ b/client/lists/mylists.html
@@ -22,8 +22,8 @@
             <span ng-if="list.collab_email">{{list.collab_email}}</span>
             <a ng-click="list.showCollabForm = list._id" ng-if="!list.collab_email" class="btn btn-primary btn-sm active">Add Collaborator</a>
             <div ng-show="list.showCollabForm === list._id" class="collabForm">
-              <input ng-model="collabForm" placeholder="Enter email address"/>
-              <a ng-click="addCollabToList(collabForm)" class="btn btn-primary btn-sm active">Add</a>
+              <input ng-model="list.collab_email" placeholder="Enter email address"/>
+              <a ng-click="addCollabToList(list); list.showCollabForm = false" class="btn btn-primary btn-sm active">Add</a>
             </div>
           </td>
           <td><a ng-click="deleteList(this.list._id, $index)" class="btn btn-primary btn-sm active">Delete List</a></td>

--- a/client/lists/mylists.html
+++ b/client/lists/mylists.html
@@ -29,7 +29,7 @@
             </div>
           </td>
           <td><a ng-click="deleteList(this.list._id, $index)" class="btn btn-primary btn-sm active">Delete List</a></td>
-          <td ng-if="list.draft"><a ng-click="displayDetail(this.list._id)" class="btn btn-primary btn-sm active">Edit Draft</a></td>
+          <td ng-if="list.draft"><a ng-click="displayDetail(list.draftObj)" class="btn btn-primary btn-sm active">Edit Draft</a></td>
           <td ng-if="!list.deliverer_id && !list.draft">Open</td>
           <td ng-if="!!list.deliverer_id && !!list.draft">In Work!</td>
         </tr>

--- a/client/lists/mylists.html
+++ b/client/lists/mylists.html
@@ -8,6 +8,7 @@
           <th>List Name</th>
           <th>Location</th>
           <th>Due</th>
+          <th>Collaborator</th>
           <th></th>
           <th>Status</th>
         </tr>
@@ -17,6 +18,10 @@
           <td ng-click="displayDetail(this.list._id)">{{ list.name }}</td>
           <td ng-click="displayDetail(this.list._id)">{{ list.delivery_address.city }}, {{ list.delivery_address.state }}</td>
           <td ng-click="displayDetail(this.list._id)"><span am-time-ago="list.due_at"></span></td>
+          <td>
+            <span ng-if="list.collab_email">{{list.collab_email}}</span>
+            <a ng-if="!list.collab_email" class="btn btn-primary btn-sm active">Add Collaborator</a>
+          </td>
           <td><a ng-click="deleteList(this.list._id, $index)" class="btn btn-primary btn-sm active">Delete List</a></td>
           <td ng-if="!list.deliverer_id">Open</td>
           <td ng-if="!!list.deliverer_id">In Work!</td>

--- a/client/style.css
+++ b/client/style.css
@@ -55,3 +55,14 @@ body {
   height: 500px;
   width: 100%;
 }
+
+/*CUSTOM CSS - mylists.html*/
+
+.collabForm {
+  position: absolute;
+  margin-top: 10px;
+  margin-left: 5px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+}

--- a/client/style.css
+++ b/client/style.css
@@ -66,3 +66,9 @@ body {
   display: flex;
   flex-direction: column;
 }
+
+.collabLabel {
+  position: absolute;
+  margin-left: 10px;
+  font-size: .8em;
+}

--- a/server/lists/listHandler.js
+++ b/server/lists/listHandler.js
@@ -19,6 +19,19 @@ var mongoose = require('mongoose');
         console.log('new list created', res)
       })
     })
+  };
+
+  var _removeCollabList = function(draftObj) {
+    List.find({"draftObj": draftObj}, function(err, results){
+      results.forEach(function(item){
+        if (item.submitted !== true) {
+          console.log(item)
+          List.remove({"_id": item._id}, function(err, results){
+            if (err) {console.log(err)}
+          })
+        }
+      })
+    })
   }
 
 
@@ -54,7 +67,7 @@ module.exports = {
     var updatedItems = req.body.items;
     console.log(req.body)
     var draftObj = req.body.draftObj;
-
+    var draft = req.body.draft;
     // var conditions = {'creator_id': id, 'due_at': due_at, 'name': name, 'deliverer_id': ''};
     // var update = {'deliverer_id': req.body.deliverer_id};
 
@@ -68,7 +81,20 @@ module.exports = {
           list.deliverer_id = req.body.deliverer_id;
           list.collab_email = req.body.collab_email;
           console.log(list, list.update)
-          if (updatedItems && draftObj) {
+           if (draft === 'final') {
+            list.draft = null;
+            list.submitted = true;
+            list.save(function(err){
+              _removeCollabList(list.draftObj)
+            });
+            res.json(list)
+          } else if (updatedItems && draft) {
+            // if (draft === 'final') {
+            //   list.draft = null;
+            //   list.submitted = true;
+            //   list.save();
+            //   _removeCollabList(list.draftObj)
+            // }
             list.items = updatedItems;
             list.save();
             res.json(list)

--- a/server/lists/listHandler.js
+++ b/server/lists/listHandler.js
@@ -33,13 +33,14 @@ module.exports = {
   // addList method
   addList: function(req, res){
     var newListObj = req.body;
-
     List.create(newListObj, function(err, list){
       if (err) { // notifies if error is thrown
         console.log("mongo create list err: ", err);
         helper.sendError(err, req, res);
       } else { // list created, sends 201 status
         //res.status(201);
+        list.draftObj = list._id;
+        list.save();
         res.json(list);
       }
     });
@@ -52,6 +53,10 @@ module.exports = {
     var name = req.body.name;
     var updatedItems = req.body.items;
     console.log(req.body)
+    var draftId = req.body.draft;
+    if (draftId && draftId !== id) {
+      id = draftId;
+    }
 
     // var conditions = {'creator_id': id, 'due_at': due_at, 'name': name, 'deliverer_id': ''};
     // var update = {'deliverer_id': req.body.deliverer_id};
@@ -66,7 +71,7 @@ module.exports = {
           list.deliverer_id = req.body.deliverer_id;
           list.collab_email = req.body.collab_email;
           console.log(list, list.update)
-          if (updatedItems) {
+          if (updatedItems && draftId) {
             list.items = updatedItems;
             list.save();
             res.json(list)

--- a/server/lists/listHandler.js
+++ b/server/lists/listHandler.js
@@ -53,10 +53,7 @@ module.exports = {
     var name = req.body.name;
     var updatedItems = req.body.items;
     console.log(req.body)
-    var draftId = req.body.draft;
-    if (draftId && draftId !== id) {
-      id = draftId;
-    }
+    var draftObj = req.body.draftObj;
 
     // var conditions = {'creator_id': id, 'due_at': due_at, 'name': name, 'deliverer_id': ''};
     // var update = {'deliverer_id': req.body.deliverer_id};
@@ -71,7 +68,7 @@ module.exports = {
           list.deliverer_id = req.body.deliverer_id;
           list.collab_email = req.body.collab_email;
           console.log(list, list.update)
-          if (updatedItems && draftId) {
+          if (updatedItems && draftObj) {
             list.items = updatedItems;
             list.save();
             res.json(list)

--- a/server/lists/listHandler.js
+++ b/server/lists/listHandler.js
@@ -42,6 +42,7 @@ module.exports = {
             console.error(err);
           }
           list.deliverer_id = req.body.deliverer_id;
+          list.collab_email = req.body.collab_email;
           list.save();
           res.json(list);
         }

--- a/server/lists/listHandler.js
+++ b/server/lists/listHandler.js
@@ -50,6 +50,8 @@ module.exports = {
     var id = req.body.creator_id;
     var due_at = req.body.due_at;
     var name = req.body.name;
+    var updatedItems = req.body.items;
+    console.log(req.body)
 
     // var conditions = {'creator_id': id, 'due_at': due_at, 'name': name, 'deliverer_id': ''};
     // var update = {'deliverer_id': req.body.deliverer_id};
@@ -63,7 +65,12 @@ module.exports = {
           }
           list.deliverer_id = req.body.deliverer_id;
           list.collab_email = req.body.collab_email;
-          if (list.collab_email) {
+          console.log(list, list.update)
+          if (updatedItems) {
+            list.items = updatedItems;
+            list.save();
+            res.json(list)
+          } else if (list.collab_email) {
             User.find({"email": list.collab_email}, function(err, user){
               if (user.length === 0) {
                 res.json('user does not exist')
@@ -74,19 +81,19 @@ module.exports = {
                   var listCopy = list;
                   listCopy._id = ObjectId();
                   listCopy.isNew = true;
-                  listCopy.save()
+                  listCopy.save();
                   _copyCollabList(listCopy, user);
                 }
-
-                list.save(cb)
-                res.json(list)
+                list.draft = id;
+                list.save(cb);
+                res.json(list);
               }
             })
           } else {
             list.save();
             res.json(list);
           }
-        }
+        }.bind(this)
     );
 
   },

--- a/server/lists/listModel.js
+++ b/server/lists/listModel.js
@@ -11,7 +11,7 @@ var ListSchema = new mongoose.Schema({
   expired_at: Date,
   creator_id: String,
   deliverer_id: String,
-  collab_id: String,
+  collab_email: String,
   //items is a array containing all list items
   //Each item should be follow this structure:
   // {

--- a/server/lists/listModel.js
+++ b/server/lists/listModel.js
@@ -14,6 +14,7 @@ var ListSchema = new mongoose.Schema({
   collab_email: String,
   draft: String,
   draftObj: String,
+  submitted: Boolean,
   //items is a array containing all list items
   //Each item should be follow this structure:
   // {

--- a/server/lists/listModel.js
+++ b/server/lists/listModel.js
@@ -11,7 +11,7 @@ var ListSchema = new mongoose.Schema({
   expired_at: Date,
   creator_id: String,
   deliverer_id: String,
-
+  collab_id: String,
   //items is a array containing all list items
   //Each item should be follow this structure:
   // {

--- a/server/lists/listModel.js
+++ b/server/lists/listModel.js
@@ -12,6 +12,7 @@ var ListSchema = new mongoose.Schema({
   creator_id: String,
   deliverer_id: String,
   collab_email: String,
+  draft: String,
   //items is a array containing all list items
   //Each item should be follow this structure:
   // {

--- a/server/lists/listModel.js
+++ b/server/lists/listModel.js
@@ -13,6 +13,7 @@ var ListSchema = new mongoose.Schema({
   deliverer_id: String,
   collab_email: String,
   draft: String,
+  draftObj: String,
   //items is a array containing all list items
   //Each item should be follow this structure:
   // {


### PR DESCRIPTION
Tested locally by creating a list, sharing, then adding items from both users, then submitting and verifying that it appears in AlllLists
- Adds a draft mode for collaborators
  --- Draft mode starts after adding a collaborator's email
  --- Collabs can add items to the same list
  --- Collab's items will be marked
  --- Only emails in system can be used
- Adds new properties to listModel schema, draft, draftObj and submitted
- Adds ability to add items to created lists (those will be not shown for jobs after a collab is added)
- Updates listHandler on backend with helper funcs and changes updateList to support different states of collaboration on the list.
- The main states are:
  1. Creating list
  2. Adding collab to list (draft mode active for this list now)
  3. Adding items to list
  4. Submitting list for service providers (draft mode now off)
